### PR TITLE
Issue 10: Fix broken -parent parameter for gui_add_page/group/param/text

### DIFF
--- a/ip_packager/gui.tcl
+++ b/ip_packager/gui.tcl
@@ -50,7 +50,7 @@ proc ::xtools::ip_packager::gui_add_page {args} {
 
     # Add new page to IP GUI
     if {[info exists parent]} {
-        set CurrentGuiParent [gui_set_parent $parent]
+        gui_set_parent $parent
     }
     set CurrentGuiPage [ipgui::add_page -name $page_name -component [ipx::current_core] -parent $CurrentGuiParent]
     if {[info exists display_name]} {set_property display_name $display_name $CurrentGuiPage}
@@ -90,7 +90,7 @@ proc ::xtools::ip_packager::gui_add_group {args} {
 
     # Add new group to IP GUI
     if {[info exists parent]} {
-        set CurrentGuiParent [gui_set_parent $parent]
+        gui_set_parent $parent
     }
     set CurrentGuiGroup [ipgui::add_group -name $group_name -component [ipx::current_core] -parent $CurrentGuiParent]
     if {[info exists display_name]} {set_property display_name $display_name $CurrentGuiGroup}
@@ -136,7 +136,7 @@ proc ::xtools::ip_packager::gui_add_param {args} {
 
     # Add existing IP parameter to IP GUI
     if {[info exists parent]} {
-        set CurrentGuiParent [gui_set_parent $parent]
+        gui_set_parent $parent
     }
 
     # Verify if param_name is a valid user parameter
@@ -182,7 +182,7 @@ proc ::xtools::ip_packager::gui_add_text {args} {
 
     # Add new text to IP GUI
     if {[info exists parent]} {
-        set CurrentGuiParent [gui_set_parent $parent]
+        gui_set_parent $parent
     }
     set CurrentGuiText [ipgui::add_static_text -name $text_name -component [ipx::current_core] -parent $CurrentGuiParent -text $text]
     if {[info exists tooltip]} {set_property tooltip $tooltip $CurrentGuiText}

--- a/ip_packager/test/test_ipi/package/package_externally.tcl
+++ b/ip_packager/test/test_ipi/package/package_externally.tcl
@@ -372,41 +372,48 @@ ip_packager::set_interface_enablement   -interface_name         "UART" \
 # Customization GUI
 ###################################################################################################
 
-# ROOT --------------------------------------------------------------------------------------------
-ip_packager::gui_set_parent     "root"
+# Use -parent option to define GUI structure
 
-ip_packager::gui_add_page       -page_name      "Page_UserParam" \
+# ROOT --------------------------------------------------------------------------------------------
+
+ip_packager::gui_add_page       -page_name      "Page User Param" \
                                 -display_name   "User Parameters" \
                                 -tooltip        "User Parameters Page" \
                                 -layout         "vertical" \
+                                -parent         "root" \
 
     # PAGE User Parameters ------------------------------------------------------------------------
-    ip_packager::gui_add_group      -group_name     "Group_HExample" \
+    ip_packager::gui_add_group      -group_name     "Group HExample" \
                                     -display_name   "Example (horizontal)" \
                                     -tooltip        "Horizontal Group Example" \
                                     -layout         "horizontal" \
+                                    -parent         "Page User Param" \
 
         # GROUP Horizontal Example ----------------------------------------------------------------
         ip_packager::gui_add_param      -param_name     "TestBool_p" \
                                         -display_name   "Random Boolean" \
                                         -tooltip        "Settings Tooltip" \
+                                        -parent         "Group HExample" \
 
         ip_packager::gui_add_param      -param_name     "TestLong_p" \
                                         -display_name   "Random Long" \
                                         -tooltip        "Long Tooltip" \
+                                        -parent         "Group HExample" \
 
         ip_packager::gui_add_param      -param_name     "TestFloat_p" \
                                         -display_name   "Random Float" \
                                         -tooltip        "Float Tooltip" \
                                         -widget         "comboBox" \
+                                        -parent         "Group HExample" \
 
     # PAGE User Parameters ------------------------------------------------------------------------
-    ip_packager::gui_set_parent     "Page_UserParam"
+    # ip_packager::gui_set_parent     "Page User Param"
 
-    ip_packager::gui_add_group      -group_name     "Group_VExample" \
+    ip_packager::gui_add_group      -group_name     "Group VExample" \
                                     -display_name   "Example (vertical)" \
                                     -tooltip        "Vertical Group Example" \
                                     -layout         "vertical" \
+                                    -parent         "Page User Param" \
 
         # GROUP Vertical Example ------------------------------------------------------------------
         ip_packager::gui_add_param      -param_name     "TestBitString_p" \
@@ -414,14 +421,19 @@ ip_packager::gui_add_page       -page_name      "Page_UserParam" \
                                         -tooltip        "BitString Tooltip" \
                                         -widget         "radioGroup" \
                                         -layout         "horizontal" \
+                                        -parent         "Group VExample" \
 
         ip_packager::gui_add_param      -param_name     "TestString_p" \
                                         -display_name   "Random String" \
                                         -tooltip        "String Tooltip" \
+                                        -parent         "Group VExample" \
 
         ip_packager::gui_add_text       -text_name      "TestText_t" \
                                         -text           "This is a dummy Text!" \
                                         -tooltip        "Text Tooltip" \
+                                        -parent         "Group VExample" \
+
+# Use gui_set_parent procedure to define GUI structure
 
 # ROOT --------------------------------------------------------------------------------------------
 ip_packager::gui_set_parent     "root"

--- a/ip_packager/test/test_ipi/package/package_internally.tcl
+++ b/ip_packager/test/test_ipi/package/package_internally.tcl
@@ -351,41 +351,48 @@ ip_packager::set_interface_enablement   -interface_name         "UART" \
 # Customization GUI
 ###################################################################################################
 
-# ROOT --------------------------------------------------------------------------------------------
-ip_packager::gui_set_parent     "root"
+# Use -parent option to define GUI structure
 
-ip_packager::gui_add_page       -page_name      "Page_UserParam" \
+# ROOT --------------------------------------------------------------------------------------------
+
+ip_packager::gui_add_page       -page_name      "Page User Param" \
                                 -display_name   "User Parameters" \
                                 -tooltip        "User Parameters Page" \
                                 -layout         "vertical" \
+                                -parent         "root" \
 
     # PAGE User Parameters ------------------------------------------------------------------------
-    ip_packager::gui_add_group      -group_name     "Group_HExample" \
+    ip_packager::gui_add_group      -group_name     "Group HExample" \
                                     -display_name   "Example (horizontal)" \
                                     -tooltip        "Horizontal Group Example" \
                                     -layout         "horizontal" \
+                                    -parent         "Page User Param" \
 
         # GROUP Horizontal Example ----------------------------------------------------------------
         ip_packager::gui_add_param      -param_name     "TestBool_p" \
                                         -display_name   "Random Boolean" \
                                         -tooltip        "Settings Tooltip" \
+                                        -parent         "Group HExample" \
 
         ip_packager::gui_add_param      -param_name     "TestLong_p" \
                                         -display_name   "Random Long" \
                                         -tooltip        "Long Tooltip" \
+                                        -parent         "Group HExample" \
 
         ip_packager::gui_add_param      -param_name     "TestFloat_p" \
                                         -display_name   "Random Float" \
                                         -tooltip        "Float Tooltip" \
                                         -widget         "comboBox" \
+                                        -parent         "Group HExample" \
 
     # PAGE User Parameters ------------------------------------------------------------------------
-    ip_packager::gui_set_parent     "Page_UserParam"
+    # ip_packager::gui_set_parent     "Page User Param"
 
-    ip_packager::gui_add_group      -group_name     "Group_VExample" \
+    ip_packager::gui_add_group      -group_name     "Group VExample" \
                                     -display_name   "Example (vertical)" \
                                     -tooltip        "Vertical Group Example" \
                                     -layout         "vertical" \
+                                    -parent         "Page User Param" \
 
         # GROUP Vertical Example ------------------------------------------------------------------
         ip_packager::gui_add_param      -param_name     "TestBitString_p" \
@@ -393,14 +400,19 @@ ip_packager::gui_add_page       -page_name      "Page_UserParam" \
                                         -tooltip        "BitString Tooltip" \
                                         -widget         "radioGroup" \
                                         -layout         "horizontal" \
+                                        -parent         "Group VExample" \
 
         ip_packager::gui_add_param      -param_name     "TestString_p" \
                                         -display_name   "Random String" \
                                         -tooltip        "String Tooltip" \
+                                        -parent         "Group VExample" \
 
         ip_packager::gui_add_text       -text_name      "TestText_t" \
                                         -text           "This is a dummy Text!" \
                                         -tooltip        "Text Tooltip" \
+                                        -parent         "Group VExample" \
+
+# Use gui_set_parent procedure to define GUI structure
 
 # ROOT --------------------------------------------------------------------------------------------
 ip_packager::gui_set_parent     "root"


### PR DESCRIPTION
Based on #10 this bug was found.

No arguments to any procedures changes, therefore this patch is fully backwards-compatible.