### PR TITLE
test: remove hardcoded FPGA part definition

### DIFF
--- a/ip_packager/test/test_ipi/package/package_externally.tcl
+++ b/ip_packager/test/test_ipi/package/package_externally.tcl
@@ -45,7 +45,6 @@ ip_packager::create_package_project     -prj_name       "packager_prj" \
                                         -root_dir       $root_dir \
                                         -top_file       "${src_dir}/hdl/IpPackager_2020_1_ipi.vhd" \
                                         -copy_to        "hdl" \
-                                        -part           "xc7z020iclg400-1L"
 
 ###################################################################################################
 # Identification

--- a/ip_packager/test/test_ipi/package/package_internally.tcl
+++ b/ip_packager/test/test_ipi/package/package_internally.tcl
@@ -41,7 +41,6 @@ ip_packager::create_package_project     -prj_name       "packager_prj" \
                                         -root_dir       $root_dir \
                                         -top_file       "hdl/IpPackager_2020_1_ipi.vhd" \
                                         -library        "test" \
-                                        -part           "xc7z020iclg400-1L" \
 
 ###################################################################################################
 # Identification


### PR DESCRIPTION
Updates the test project to utilize the flexible part configuration introduced in ff8625a2f3b. Removing the hardcoded part name ensures that the test project can run on all installations, regardless of which specific device parts are locally installed.